### PR TITLE
Fix segfault when calling Error.throw on x86-32

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -165,6 +165,13 @@ sl_error_backtrace(sl_vm_t* vm, SLVAL self)
 }
 
 static SLVAL
+sl_error_throw(sl_vm_t* vm, SLVAL self)
+{
+    sl_throw(vm, self);
+    return vm->lib.nil;
+}
+
+static SLVAL
 sl_error_to_s(sl_vm_t* vm, SLVAL self)
 {
     sl_error_t* error = get_error(vm, self);
@@ -235,7 +242,7 @@ sl_init_error(sl_vm_t* vm)
     sl_define_method(vm, vm->lib.Error, "message", 0, sl_error_message);
     sl_define_method(vm, vm->lib.Error, "backtrace", 0, sl_error_backtrace);
     sl_define_method(vm, vm->lib.Error, "to_s", 0, sl_error_to_s);
-    sl_define_method(vm, vm->lib.Error, "throw", 0, (SLVAL(*)())sl_throw);
+    sl_define_method(vm, vm->lib.Error, "throw", 0, sl_error_throw);
     
     vm->lib.Error_Frame = sl_define_class3(vm, sl_intern(vm, "Frame"), vm->lib.Object, vm->lib.Error);
     sl_class_set_allocator(vm, vm->lib.Error_Frame, allocate_error_frame);


### PR DESCRIPTION
Slash produces a segfault when executing "Error.new.throw" on 32-bit
systems.

Steps to reproduce:
1. You need a 32-bit system (I tested it successfully on "bare metal" and a 32 bit guest vm on top of a 64 bit host)
2. Apply the `throw` method of an `Error`-instance:
   
   ```
   $ ./sapi/cli/slash-cli
   Interactive Slash
   >> Error.new.throw
   Segmentation fault
   ```

The problem is that `sl_throw` has no return value (`void`) but gets called
as if it would return a `SLVAL`. The address of the return value is then
added by the caller before the other parameters. If that happens, the
`vm`-parameter contains the address to uninitialized `SLVAL` of the
caller - which is of course invalid.

This fix solves the problem by just wrapping the `sl_throw` call in a
function with a matching function signature. That way the return value
is "pop"-ed before the parameters.

This problem does not appear on 64-bit systems because the return value
has a dedicated register and does not "get in the way" of the other
parameters.
