### PR TITLE
Throw a TypeError if the extends expression does not evaluate to a Class

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -293,7 +293,8 @@ sl_make_class(sl_vm_t* vm, SLVAL vsuper)
     SLVAL vsing = sl_allocate(vm, vm->lib.Class);
     sl_class_t* sing = (sl_class_t*)sl_get_ptr(vsing);
 
-    sl_class_t* super = (sl_class_t*)sl_get_ptr(vsuper);
+    sl_class_t* super = (sl_class_t*)sl_get_ptr(
+        sl_expect(vm, vsuper, vm->lib.Class));
 
     sing->extra->allocator = NULL;
     sing->super = super->base.klass;

--- a/test/core/class.sl
+++ b/test/core/class.sl
@@ -131,4 +131,16 @@ class ClassTest extends Test {
         assert_equal("class_test", ClassTest.file_path);
         assert_equal("class_test/foo", ClassTest::Foo.file_path);
     }
+
+    def test_extends_is_a_class {
+        assert_throws(TypeError, \{ class InvalidClass1 extends 1 {} } );
+        assert_throws(TypeError, \{ class InvalidClass2 extends "" {} } );
+
+        try {
+            class ValidClass1 extends 1.class {};
+            assert_is_a(Int, ValidClass1.new);
+        } catch e {
+            assert(false, "Invalid exception on valid class declaration");
+        }
+    }
 }


### PR DESCRIPTION
If the `extends`/super expression does not evaluate to a Class-instance, slash still tries to use it as a `sl_class_t` type, which results in a segmentation fault, when it is used.

Example:

```
>> class Test extends 1 {}
Segmentation fault
```

This PR just adds a type-check before the `vsuper` value is actually used.
